### PR TITLE
Typo in str_getcsv description

### DIFF
--- a/reference/strings/functions/str-getcsv.xml
+++ b/reference/strings/functions/str-getcsv.xml
@@ -68,8 +68,8 @@
       </para>
       <note>
        <simpara>
-        En général un caractère d'encadrement <parameter>enclosure</parameter> est
-        échapper à l'intérieur d'un champ en le dédoublant;
+        En général, à l'intérieur d'un champ, un caractère d'encadrement <parameter>enclosure</parameter> est
+        échappé en le dédoublant.
         Cependant, le caractère d'échappement <parameter>escape</parameter> peut être utilisé comme une alternative.
         Donc pour la valeur par défaut <literal>""</literal> et <literal>\"</literal>
         ont la même signification. Outre échapper le caractère d'encadrement <parameter>enclosure</parameter>


### PR DESCRIPTION
Fixed a small typo (`échappé` instead of `échapper`), and tried to clarify the meaning by moving `à l'intérieur d'un champ` earlier in the sentence.

What do you think? 🙂 